### PR TITLE
Multistage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
-FROM alpine:3.4
+FROM golang:1.9-alpine AS build
+RUN \
+     apk update \
+  && apk add git make curl \
+  && (curl https://glide.sh/get | sh)
+RUN mkdir -p /go/src/github.com/sstarcher/job-reaper
+WORKDIR /go/src/github.com/sstarcher/job-reaper/
+COPY . .
+RUN \
+     glide install \
+  && make build
 
-COPY job-reaper /
-ENTRYPOINT ["/job-reaper"]
+FROM golang:1.9-alpine
+COPY --from=build /go/src/github.com/sstarcher/job-reaper/build/job-reaper /bin/
+ENTRYPOINT ["/bin/job-reaper"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-TEST?=$$(glide nv)
+TEST? = $$(glide nv)
+
+GO_SOURCE_FILES = $(shell find . -type f -name "*.go" | grep -v /vendor/)
 
 vendor:
 	glide install
@@ -14,7 +16,7 @@ clean:
 test: vendor
 	go test -v $(TEST)
 
-build: vendor
+build: vendor $(GO_SOURCE_FILES)
 	go build -o build/job-reaper cmd/main.go
 
 run: build


### PR DESCRIPTION
Make Dockerfile use multistage build, so we can build the binary using Docker (without leaving any compilers or build artifacts behind in the final image). Note that this requires Docker 17.05 or later.