### PR TITLE
Allowing the k8s client 3 QPS per reaper thread

### DIFF
--- a/kube/kube.go
+++ b/kube/kube.go
@@ -64,6 +64,8 @@ func NewKubeClient(masterURL string, failures int, alerters *[]alert.Alert, reap
 	if err != nil {
 		log.Panic(err.Error())
 	}
+	config.QPS = float32(3 * reaperCount)
+	config.Burst = int(2 * config.QPS)
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Panic(err.Error())


### PR DESCRIPTION
This addresses #11.

The idea is to let each reaper thread have 3 QPS because that's the minimum number of requests required to delete a job.  Each reaper can handle about 1 job/second, keeping it simple to scale the number of reapers to the required rate.

Default behavior remains intact.  With default `--reapers=2`, QPS goes from 5 to 6 and maximum burst goes from 10 to 12.